### PR TITLE
Compatibility of code upgrade to Java 11

### DIFF
--- a/agent/arcus-os/src/main/java/com/iris/agent/os/serial/UartNative.java
+++ b/agent/arcus-os/src/main/java/com/iris/agent/os/serial/UartNative.java
@@ -15,11 +15,8 @@
  */
 package com.iris.agent.os.serial;
 
-import java.io.Closeable;
-import java.io.FileDescriptor;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
+import java.lang.reflect.Field;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 
@@ -60,13 +57,23 @@ public final class UartNative {
    }
 
    private static FileChannel toFileChannel(FileDescriptor fd, String path) {
-      return sun.nio.ch.FileChannelImpl.open(fd, path, true, true, false, null);
+      try {
+         RandomAccessFile raf = new RandomAccessFile(path, "rw");
+         Field fdField = RandomAccessFile.class.getDeclaredField("fd");
+         fdField.setAccessible(true);
+         fdField.set(raf, fd);
+         return raf.getChannel();
+      } catch (FileNotFoundException | IllegalAccessException | NoSuchFieldException e) {
+          throw new RuntimeException(e);
+      }
    }
 
    private static FileDescriptor toFileDescriptor(int fd) {
       try {
          FileDescriptor fdesc = new FileDescriptor();
-         sun.misc.SharedSecrets.getJavaIOFileDescriptorAccess().set(fdesc, fd);
+         Field field = FileDescriptor.class.getDeclaredField("fd");
+         field.setAccessible(true);
+         field.set(fdesc, fd);
          return fdesc;
       } catch (Exception ex) {
          throw new UnsupportedOperationException(ex);

--- a/agent/arcus-os/src/main/java/com/iris/agent/os/watchdog/WatchdogNative.java
+++ b/agent/arcus-os/src/main/java/com/iris/agent/os/watchdog/WatchdogNative.java
@@ -17,6 +17,7 @@ package com.iris.agent.os.watchdog;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.Set;
 
 import com.sun.jna.Platform;
@@ -92,8 +93,10 @@ public final class WatchdogNative {
 
    private static int fd(FileOutputStream os) {
       try {
-         return sun.misc.SharedSecrets.getJavaIOFileDescriptorAccess().get(os.getFD());
-      } catch (IOException ex) {
+         Field field = os.getFD().getClass().getDeclaredField("fd");
+         field.setAccessible(true);
+         return field.getInt(os.getFD());
+      } catch (IOException | IllegalAccessException | NoSuchFieldException ex) {
          throw new RuntimeException(ex);
       }
    }


### PR DESCRIPTION
Removed old sun methods which were part of the internal Java API in favor of using reflection for file management